### PR TITLE
Run action with Ansible 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The molecule scenario to run. Default `default`
 
 If `false` you are responsible for creating the Python environment, default `true` (this action will create a virtualenv `~/venv` and install dependencies).
 
+### `ome-ansible-molecule-version`
+
+The version of the ome-ansible-molecule meta-package to install for running the
+Molecule tests. Default: 0.5.*
+
 ## Example usage
 
 Here is a default configuration.
@@ -30,5 +35,5 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: molecule
-        uses: manics/action-ome-ansible-molecule@main
+        uses: ome/action-ome-ansible-molecule@main
 ```

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
       responsible for installing dependencies
     required: false
     default: "true"
+  ome-ansible-molecule-version:
+    description: The version of ome-ansible-molecule
+    required: false
+    default: "0.5.*"
 
 runs:
   using: "composite"
@@ -31,7 +35,7 @@ runs:
       run: |
         if [[ "${{ inputs.manage-virtualenv }}" == "true" ]]; then
           python3 -mvenv ~/venv
-          ~/venv/bin/pip install "ome-ansible-molecule==0.4.*"
+          ~/venv/bin/pip install "ome-ansible-molecule==${{ inputs.ome-ansible-molecule-version }}"
           echo PATH=~/venv/bin:$PATH >> $GITHUB_ENV
           echo VIRTUAL_ENV=~/venv >> $GITHUB_ENV
         fi


### PR DESCRIPTION
This PR includes the following changes

- Bump the `ome-ansible-molecule` version to 0.5.x
- Add support for making the `ome-ansible-molecule` version an input variable, allowing

Tested against the various playbooks repositories including the Ansible lint fixes

- https://github.com/sbesson/deployment/actions/runs/503731755
- https://github.com/sbesson/ansible-example-omero-addons/actions/runs/502321553
- https://github.com/sbesson/ansible-example-omero-onenode/actions/runs/502114111
- https://github.com/sbesson/ansible-example-omero-public-user/actions/runs/502268187
- https://github.com/sbesson/ansible-example-omero-three-nodes/actions/runs/502178408
- https://github.com/sbesson/prod-playbooks/runs/1748995953

and a few roles:

- https://github.com/sbesson/ansible-role-java/actions/runs/503288764
- https://github.com/sbesson/ansible-role-omero-server/runs/1749467774

As this contains no breaking logic in the role, I would propose to tag 427275ed794cf8181ad269611ae03e0b532f433e as `v1.0.0`, release PR as `v1.1.0` and create a `v1` tag tracking the latest as per https://docs.github.com/en/actions/creating-actions/about-actions#using-tags-for-release-management